### PR TITLE
Fix possible ConcurrentModificationException

### DIFF
--- a/src/main/java/io/github/sebseb7/loadedChunks/Loadedchunks.java
+++ b/src/main/java/io/github/sebseb7/loadedChunks/Loadedchunks.java
@@ -3,8 +3,9 @@ package io.github.sebseb7.loadedChunks;
 import io.github.sebseb7.loadedchunks.listener.ChunkLoadListener;
 import io.github.sebseb7.loadedchunks.listener.ChunkUnloadListener;
 import io.github.sebseb7.loadedchunks.tasks.Update;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -33,7 +34,7 @@ public final class Loadedchunks extends JavaPlugin {
       getServer().getPluginManager().disablePlugin(this);
       return;
     }
-    markermap = new HashMap<>();
+    markermap = new ConcurrentHashMap<>();
     api = (DynmapAPI) dynmap;
     getServer().getConsoleSender().sendMessage("Loaded");
 


### PR DESCRIPTION
Since `Loadedchunks#markermap` is accessed by multiple Threads  (2 async update tasks), using a HashMap may produce a ConcurrentModificationException.
Replacing it with a ConcurrentHashMap avoids this issue while barely impacting performance or functionality.